### PR TITLE
fix: 메인 페이지 CSS 오류 수정 (#21)

### DIFF
--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -29,6 +29,7 @@ const Wrapper = styled.div`
   display: flex;
   background: linear-gradient(180deg, #FFDA58 0%, #FFDA58 5%, #FFFFFF 16%);
   height: 100vh;
+  width: 100vw;
   justify-content: center;
   align-items: center;
   gap: 68px;


### PR DESCRIPTION
## PR 타입
fix

## 반영 브랜치
fix/#21 -> main

## 작업 내용
- width를 100vw으로 설정해서 메인 페이지가 화면 전체에 보이도록 함.
- 오류
![image](https://github.com/2024-StudyBuddy/Front-end/assets/71203375/585b84ab-1342-4ab5-875e-0ae81b1a3684)
 
- 오류 수정
![image](https://github.com/2024-StudyBuddy/Front-end/assets/71203375/7390346c-0fd8-471b-9f47-84bb94efd616)


## 리뷰 요구 사항 (선택)