### PR TITLE
Fix: Home 페이지 관련 ui 수정 (#45)

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -74,9 +74,9 @@ const Profile = styled.img`
 
 const Study = styled.div`
   display: flex;
-  height: 41vh;
+  min-height: 41vh;
   background-color: #f5f5f5;
-  padding: 22px 43px;
+  padding: 43px;
   box-sizing: border-box;
   gap: 15vw;
   @media (min-width: 1280px) {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -38,14 +38,14 @@ const Home: React.FC = () => {
         <SDiv>
           <STitle>스터디룸 입장</STitle>
           <SText>미리 설정한 스터디룸에서 공부를 시작하세요.</SText>
-          <StyleLink to="/room">
+          <StyleLink to="/room/:roomId">
             <img src={Btn_Enter} alt="Enter the StudyRoom" />
           </StyleLink>
         </SDiv>
         <SDiv>
           <STitle>스터디룸 생성</STitle>
           <SText>새로운 스터디룸을 만들어보세요.</SText>
-          <StyleLink to="/room/:roomId">
+          <StyleLink to="/room">
             <img src={Btn_Create} alt="Create a new StudyRoom" />
           </StyleLink>
         </SDiv>

--- a/src/shared/Header.tsx
+++ b/src/shared/Header.tsx
@@ -33,6 +33,7 @@ const RightS = styled.div``;
 const Title = styled.div`
   font-family: InterExtraBold;
   font-size: 36px;
+  margin-bottom: 20px;
 `;
 
 const Phrase = styled.div`


### PR DESCRIPTION
## PR 타입
fix

## 반영 브랜치
fix/#45 -> main

## 작업 내용
- header의 title 밑 margin 추가 (20px)
- home 페이지의 study div의 padding을 43px로 수정
- height -> min-height로 변경
- 스터디룸 url 수정

## 리뷰 요구 사항 (선택)
