### PR TITLE
feat: 스터디 도우미 ui 구현 (#47)

### DIFF
--- a/src/components/studySetting/DefaultSetting.tsx
+++ b/src/components/studySetting/DefaultSetting.tsx
@@ -73,7 +73,7 @@ const DefaultSetting: React.FC<DefaultSettingProps> = ({ setSelectedTab }) => {
   };
 
   const handlePrevButtonClick = () => {
-    setSelectedTab('2. 스터디 메이트');
+    setSelectedTab('3. 스터디 도우미');
   };
   
   const handleNextButtonClick = () => {

--- a/src/components/studySetting/StudyHelper.tsx
+++ b/src/components/studySetting/StudyHelper.tsx
@@ -1,0 +1,155 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import Radio from "./Radio";
+
+interface StudyHelperProps {
+  setSelectedTab: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const StudyHelper: React.FC<StudyHelperProps> = ({ setSelectedTab }) => {
+  const [inputStatus, setInputStatus] = useState<string>('ChatGPT');
+  
+  const handleClickButton = (buttonName: string) => {
+    setInputStatus(buttonName);
+    console.log('Selected ID:', buttonName);
+  };
+
+  const handlePrevButtonClick = () => {
+    setSelectedTab('2. 스터디 메이트');
+  };
+  
+  const handleNextButtonClick = () => {
+    setSelectedTab('4. 디폴트 설정');
+  };
+
+  return (
+    <Wrapper>
+      <div>
+        <Title>스터디 도우미</Title>
+        <Text>공부하다가 모르는게 있으면 바로 스터디 도우미에게 물어보세요!</Text>        
+      </div>
+      <GPTType>
+        <div>
+          <Radio
+            handleClickAdmin={handleClickButton}
+            selected={inputStatus === 'ChatGPT'}
+            text="ChatGPT"
+            id="ChatGPT"
+            fontSize="24px"
+            fontFamily="NotoSansSemiBold"
+          />
+          <Example>안녕하세요! 무엇을 도와드릴까요? 😊</Example>          
+        </div>
+        <div>
+          <Radio
+            handleClickAdmin={handleClickButton}
+            selected={inputStatus === '천재 너드 친구'}
+            text="천재 너드 친구"
+            id="천재 너드 친구"
+            fontSize="24px"
+            fontFamily="NotoSansSemiBold"
+          />    
+          <Example>오. 오랜만이야. 어떤. 흥미로운 질문을. 준비했지?</Example>        
+        </div>
+        <div>
+          <Radio
+            handleClickAdmin={handleClickButton}
+            selected={inputStatus === '조선시대 성균관생'}
+            text="조선시대 성균관생"
+            id="조선시대 성균관생"
+            fontSize="24px"
+            fontFamily="NotoSansSemiBold"
+          />   
+          <Example>소인에게 무엇을 명하려는지, 자세히 알려주시오.</Example>       
+        </div>
+        <div>
+          <Radio
+            handleClickAdmin={handleClickButton}
+            selected={inputStatus === '요정'}
+            text="요정"
+            id="요정"
+            fontSize="24px"
+            fontFamily="NotoSansSemiBold"
+          />          
+          <Example>뾰로롱 요정 등장~（￣︶￣）↗ 🧚✨</Example>
+        </div>
+      </GPTType>
+      <Buttons>
+        <Button onClick={handlePrevButtonClick}>이전</Button>
+        <Button onClick={handleNextButtonClick}>다음</Button>
+      </Buttons>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  width: 55vw;
+  height: 88vh;
+  background-color: #FFFFFF;
+  border: none;
+  border-radius: 0 15px 15px 0;
+  padding: 50px 100px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: scroll;
+  scrollbar-width: none; /* Firefox 용 스크롤 바 숨김 */
+  -ms-overflow-style: ne; /* IE 및 Edge 용 스크롤 바 숨김 */
+  &::-webkit-scrollbar {
+    display: none; /* Chrome 및 Safari 용 스크롤 바 숨김 */
+  }
+`;
+
+const Title = styled.div`
+  font-family: InterExtraBold;
+  font-size: 36px;
+  margin-bottom: 20px;
+`;
+
+const Text = styled.div`
+  font-family: InterExtraBold;
+  font-weight: 600;
+  font-size: 20px;
+  color: ${({ theme }) => theme.colors.subMain};
+`;
+
+const GPTType = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+`;
+
+const Example = styled.div`
+  height: 46px;
+  border-radius: 5px;
+  border: none;
+  background-color: ${({ theme }) => (theme.colors.white01 )};
+  font-size: 20px;
+  padding-left: 15px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  padding-left: 20px;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+`;
+
+const Button = styled.button`
+  width: 150px;
+  height: 54px;
+  color: #FFFFFF;
+  background-color: #586FC5;
+  font-size: 20px;
+  font-weight: 600;
+  border: none;
+  border-radius: 10px;
+  margin-top: 40px;
+  margin-bottom: 20px;
+`;
+
+export default StudyHelper;

--- a/src/components/studySetting/StudyMate.tsx
+++ b/src/components/studySetting/StudyMate.tsx
@@ -13,7 +13,7 @@ const StudyMate: React.FC<StudyMateProps> = ({ setSelectedTab }) => {
   };
   
   const handleNextButtonClick = () => {
-    setSelectedTab('3. 디폴트 설정');
+    setSelectedTab('3. 스터디 도우미');
   };
 
   return (

--- a/src/pages/StudyRoomSetting.tsx
+++ b/src/pages/StudyRoomSetting.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import SettingTab from "components/studySetting/SettingTab";
 import StudyType from "components/studySetting/StudyType";
 import StudyMate from "components/studySetting/StudyMate";
+import StudyHelper from "components/studySetting/StudyHelper";
 import DefaultSetting from "components/studySetting/DefaultSetting";
 
 const StudyRoomSetting: React.FC = () => {
@@ -15,13 +16,14 @@ const StudyRoomSetting: React.FC = () => {
   return (
     <Wrapper>
       <SettingTab
-        tabs={['1. 스터디룸 타입', '2. 스터디 메이트', '3. 디폴트 설정']}
+        tabs={['1. 스터디룸 타입', '2. 스터디 메이트', '3. 스터디 도우미', '4. 디폴트 설정']}
         selectedTab={selectedTab}
         onSelectTab={handleTabSelect}
       />
 
       {selectedTab === '1. 스터디룸 타입' ? <StudyType setSelectedTab={setSelectedTab} /> 
       : selectedTab === '2. 스터디 메이트' ? <StudyMate setSelectedTab={setSelectedTab} /> 
+      : selectedTab === '3. 스터디 도우미' ? <StudyHelper setSelectedTab={setSelectedTab} />
       : <DefaultSetting setSelectedTab={setSelectedTab} />}
 
     </Wrapper>


### PR DESCRIPTION
## PR 타입
feat, ui

## 반영 브랜치
feat/#47 -> main
closed feat/#47

## 작업 내용
- tab component에 스터디 도우미 추가
- ui 구현
- 버튼 url 수정
![image](https://github.com/2024-StudyBuddy/Front-end/assets/71203375/b89e61f4-ef0a-4258-80a2-146320050d32)

## 리뷰 요구 사항 (선택)
